### PR TITLE
Hotfix increase cities 2

### DIFF
--- a/src/app/modules/layout/components/ts-header/search/search.component.ts
+++ b/src/app/modules/layout/components/ts-header/search/search.component.ts
@@ -234,7 +234,7 @@ export class SearchComponent implements OnInit {
                 if (this.utilityService.IsJsonString(res)) {
                     const country = JSON.parse(<any>res)['country'];
                     const data = await this.headerService.getPopularCities(country || this.urlArray[0]);
-                    this.popularPlaces = data['data'].slice(0, 6).map(ele => {
+                    this.popularPlaces = data['data'].slice(0, 12).map(ele => {
                         ele.type = 'city';
                         ele.cityCode = ele.code;
                         return ele;

--- a/src/app/modules/layout/components/ts-header/ts-header.component.ts
+++ b/src/app/modules/layout/components/ts-header/ts-header.component.ts
@@ -119,7 +119,7 @@ export class TsHeaderComponent implements OnInit {
         if (this.utilityService.IsJsonString(res)) {
           const country = JSON.parse(<any>res)['country'];
           const data = await this.headerService.getPopularCities(country || this.urlArray[0]);
-          this.popularPlaces = data['data'].slice(0, 6).map(ele => {
+          this.popularPlaces = data['data'].slice(0, 12).map(ele => {
             ele.type = 'city';
             ele.cityCode = ele.code;
             return ele;

--- a/src/app/shared/components/city-search-popup/city-search-popup.component.html
+++ b/src/app/shared/components/city-search-popup/city-search-popup.component.html
@@ -11,7 +11,7 @@
                 <i *ngIf="cityLoading" class="mdi mdi-loading mdi-spin"></i>
             </div>
         </div>
-        <ul class="mb-1 cities-grid">
+        <ul class="mb-1 cities-grid" [ngClass]="{'single-column': cityQuery && cityQuery.length}">
             <div *ngIf="!closeSuggestions">
                 <li matRipple (click)="placeChanged(place);"
                     class="p-2 capitalize cursor-pointer flex items-center truncate"

--- a/src/app/shared/components/city-search-popup/city-search-popup.component.html
+++ b/src/app/shared/components/city-search-popup/city-search-popup.component.html
@@ -1,7 +1,7 @@
 <div class="city-suggestions enter-slide-bottom rounded-lg" [class.arrow]="showArrow">
     <div class="suggestions-container">
-        <ul class="mb-1">
-            <li [class.active]="citySearchActive"
+        <div class="search-input-container">
+            <div [class.active]="citySearchActive"
                 class="p-2 rounded-t-lg capitalize cursor-pointer flex items-center truncate">
                 <i class="mdi mdi-magnify text-primary mr-2 text-base"></i>
                 <input appDataAnalytics eventLabel="locationDropdownSearch" clickLocation="" #cityInput
@@ -9,7 +9,9 @@
                     (ngModelChange)="searchCity($event)" (focus)="citySearchActive=true"
                     class="w-full bg-transparent text-sm" />
                 <i *ngIf="cityLoading" class="mdi mdi-loading mdi-spin"></i>
-            </li>
+            </div>
+        </div>
+        <ul class="mb-1 cities-grid">
             <div *ngIf="!closeSuggestions">
                 <li matRipple (click)="placeChanged(place);"
                     class="p-2 capitalize cursor-pointer flex items-center truncate"
@@ -30,7 +32,7 @@
             </div>
             <ng-container matRipple *ngIf="!placeSearchResults || placeSearchResults.length==0">
                 <li appDataAnalytics eventLabel="locationDropdownItem" clickLocation=""
-                    (click)="placeChangedToOnline();" class="border-b p-2 cursor-pointer capitalize">
+                    (click)="placeChangedToOnline();" class="border-b p-2 cursor-pointer capitalize online-item">
                     <i class="mdi mdi-earth text-base mr-1 text-primary"></i>
                     <span class="text-gray-800 capitalize text-sm">Online</span>
                 </li>

--- a/src/app/shared/components/city-search-popup/city-search-popup.component.html
+++ b/src/app/shared/components/city-search-popup/city-search-popup.component.html
@@ -11,7 +11,7 @@
                 <i *ngIf="cityLoading" class="mdi mdi-loading mdi-spin"></i>
             </div>
         </div>
-        <ul class="mb-1 cities-grid" [ngClass]="{'single-column': cityQuery && cityQuery.length}">
+        <ul class="mb-1 cities-grid" [ngClass]="{'single-column': cityQuery && cityQuery.trim().length}">
             <div *ngIf="!closeSuggestions">
                 <li matRipple (click)="placeChanged(place);"
                     class="p-2 capitalize cursor-pointer flex items-center truncate"

--- a/src/app/shared/components/city-search-popup/city-search-popup.component.html
+++ b/src/app/shared/components/city-search-popup/city-search-popup.component.html
@@ -12,7 +12,7 @@
             </div>
         </div>
         <ul class="mb-1 cities-grid" [ngClass]="{'single-column': cityQuery && cityQuery.trim().length}">
-            <div *ngIf="!closeSuggestions">
+            <div *ngIf="!closeSuggestions && cityQuery && cityQuery.trim().length">
                 <li matRipple (click)="placeChanged(place);"
                     class="p-2 capitalize cursor-pointer flex items-center truncate"
                     *ngFor="let place of placeSearchResults">
@@ -30,7 +30,7 @@
                     </span>
                 </li>
             </div>
-            <ng-container matRipple *ngIf="!placeSearchResults || placeSearchResults.length==0">
+            <ng-container matRipple *ngIf="(!placeSearchResults || placeSearchResults.length==0) && (!cityQuery || !cityQuery.trim().length)">
                 <li appDataAnalytics eventLabel="locationDropdownItem" clickLocation=""
                     (click)="placeChangedToOnline();" class="border-b p-2 cursor-pointer capitalize online-item">
                     <i class="mdi mdi-earth text-base mr-1 text-primary"></i>

--- a/src/app/shared/components/city-search-popup/city-search-popup.component.scss
+++ b/src/app/shared/components/city-search-popup/city-search-popup.component.scss
@@ -8,7 +8,7 @@
         animation-duration: 0.5s;
     }
     .search-input-container {
-        width: 50%;
+        width: 100%;
         div.active {
             background: $gray--light;
         }
@@ -19,6 +19,9 @@
         gap: 0;
         margin-top: 0;
         padding-top: 0;
+        &.single-column {
+            grid-template-columns: 1fr;
+        }
         .online-item {
             grid-column: 1;
         }
@@ -46,7 +49,7 @@
 }
 @media (min-width: $screen-sm-max){
     .city-suggestions{
-        width: 140%;
-        left: -40%;
+        width: 180%;
+        left: -80%;
     }
 }

--- a/src/app/shared/components/city-search-popup/city-search-popup.component.scss
+++ b/src/app/shared/components/city-search-popup/city-search-popup.component.scss
@@ -24,7 +24,7 @@
             grid-template-columns: 1fr;
         }
         .online-item {
-            grid-column: 1;
+            grid-column: 1 / -1;
         }
     }
     li:hover, li.active, .search-input-container div:hover{

--- a/src/app/shared/components/city-search-popup/city-search-popup.component.scss
+++ b/src/app/shared/components/city-search-popup/city-search-popup.component.scss
@@ -3,6 +3,7 @@
     width: 100%;
     background: $gray--lighter;
     position: absolute;
+    overflow: hidden;
     box-shadow:  0px 0px 8px rgba(0, 0, 0, 0.25);
     .mdi-spin::before{
         animation-duration: 0.5s;

--- a/src/app/shared/components/city-search-popup/city-search-popup.component.scss
+++ b/src/app/shared/components/city-search-popup/city-search-popup.component.scss
@@ -7,15 +7,23 @@
     .mdi-spin::before{
         animation-duration: 0.5s;
     }
-    ul {
+    .search-input-container {
+        width: 50%;
+        div.active {
+            background: $gray--light;
+        }
+    }
+    .cities-grid {
         display: grid;
         grid-template-columns: repeat(2, 1fr);
         gap: 0;
-        li:first-child {
-            grid-column: 1 / -1;
+        margin-top: 0;
+        padding-top: 0;
+        .online-item {
+            grid-column: 1;
         }
     }
-    li:hover, li.active{
+    li:hover, li.active, .search-input-container div:hover{
         background: $gray--light;
     }
     &.arrow{

--- a/src/app/shared/components/city-search-popup/city-search-popup.component.scss
+++ b/src/app/shared/components/city-search-popup/city-search-popup.component.scss
@@ -7,6 +7,14 @@
     .mdi-spin::before{
         animation-duration: 0.5s;
     }
+    ul {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 0;
+        li:first-child {
+            grid-column: 1 / -1;
+        }
+    }
     li:hover, li.active{
         background: $gray--light;
     }


### PR DESCRIPTION
This pull request focuses on improving the city search popup UI and increasing the number of popular cities shown in the header components. The main changes include updating the layout and styling for city suggestions, enhancing the search experience, and displaying more popular cities to users.

UI and UX improvements for city search popup:

* Refactored the city search popup input area in `city-search-popup.component.html` to use a dedicated container and updated the layout to display city suggestions in a two-column grid, switching to a single column when a search query is present. Also improved the logic for showing the "Online" option only when there are no search results and no search query. [[1]](diffhunk://#diff-397b55bea0c711abe497b0c7eaca4bfe6d53ea683b77501aff85ea2111b40a0dL3-R15) [[2]](diffhunk://#diff-397b55bea0c711abe497b0c7eaca4bfe6d53ea683b77501aff85ea2111b40a0dL31-R35)
* Updated styles in `city-search-popup.component.scss` to support the new grid layout for city suggestions, added styling for the input container, and adjusted hover/active states.
* Modified the city suggestions popup width and position for larger screens to accommodate the new layout.

Header component enhancements:

* Increased the number of popular cities shown in both `search.component.ts` and `ts-header.component.ts` from 6 to 12, providing users with more options in the header. [[1]](diffhunk://#diff-ea04faa45008276ff12876a00794d7ea5d467ad59b8226a961f3e975f0f27221L237-R237) [[2]](diffhunk://#diff-205fa3145669d49dd7d78fb52135678f1fbea7fdbefd08af51c46ba0a09f2ef5L122-R122)